### PR TITLE
run install prior to running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ ENV PROJECT $PROJECT
 RUN npm run build --project common
 
 EXPOSE 4200
-CMD npm run start ${PROJECT} -- --host 0.0.0.0
+CMD npm install && npm run start ${PROJECT} -- --host 0.0.0.0


### PR DESCRIPTION
  In case of a shared folder the install happened during the build phase of docker. When overlaying the app folder with a shared folder during development no install has happened (or in case of a mixed environment windows host / linux docker container) the wrong one has happened. In that case a new install should be executed prior to executing the code.